### PR TITLE
Updates debug message to account for signedness of the integer

### DIFF
--- a/nau7802.c
+++ b/nau7802.c
@@ -538,7 +538,7 @@ nau7802_read_internal(i2c_master_dev_handle_t i2c, int32_t* val, bool lognodata)
   if (*val & 0x800000) {
     *val |= 0xFF000000;
   }
-  ESP_LOGD(TAG, "ADC reads: %u %u %u full %lu 0x%08x", r0, r1, r2, *val, *val);
+  ESP_LOGD(TAG, "ADC reads: %u %u %u full %ld 0x%08lx", r0, r1, r2, *val, (uint32_t) *val);
   return ESP_OK;
 }
 


### PR DESCRIPTION
The previous version of the message tried to print a signed integer using an unsigned string format causing the following error: 

```
error: format '%x' expects argument of type 'unsigned int', but argument 10 has type 'int32_t' {aka 'long int'} [-Werror=format=]
```

Changing u to d when printing as decimal and casting to unsigned integer when printing as hex fixes the issue.